### PR TITLE
chore: loosen sphinx to remain compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Zapata Computing <zapata@zapatacomputing.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-Sphinx = "^4.3.2"
+Sphinx = ">4.3.2"
 sphinx-autoapi = "^1.8.4" 
 sphinx_rtd_theme = "*"
 clint = "^0.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Zapata Computing <zapata@zapatacomputing.com>"]
 [tool.poetry.dependencies]
 python = ">=3.7"
 Sphinx = ">4.3.2"
-sphinx-autoapi = "^1.8.4" 
+sphinx-autoapi = ">1.8.4" 
 sphinx_rtd_theme = "*"
 clint = "^0.5.1"
 argcomplete = "^2.0.0"


### PR DESCRIPTION
In order to be able to use more updated versions of sphinx in docs without `pip` throwing an error, sphinx needs to be loosened here